### PR TITLE
Fixed bug with messages and corrected message ID to reflect info level

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.bentley"
-version = '1.0.0'
+version = '1.0.1'
 
 repositories {
    mavenCentral()

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.bentley"
-version = '1.1.0'
+version = '1.0.0'
 
 repositories {
    mavenCentral()

--- a/lib/src/main/plugin.xml
+++ b/lib/src/main/plugin.xml
@@ -5,8 +5,8 @@
 * Copyright © Bentley Systems, Incorporated. All rights reserved.
 *
 ****************************************************************************** -->
-<plugin id="com.bentley.math-content" version="1.1.0">
-    <feature extension="package.version" value="1.1.0"/>
+<plugin id="com.bentley.math-content" version="1.0.0">
+    <feature extension="package.version" value="1.0.0"/>
     <feature extension="package.support.name" value="Jason Coleman"/>
     <feature extension="package.support.email" value="jason.coleman@bentley.com"/>
     

--- a/lib/src/main/plugin.xml
+++ b/lib/src/main/plugin.xml
@@ -5,8 +5,8 @@
 * Copyright © Bentley Systems, Incorporated. All rights reserved.
 *
 ****************************************************************************** -->
-<plugin id="com.bentley.math-content" version="1.0.0">
-    <feature extension="package.version" value="1.0.0"/>
+<plugin id="com.bentley.math-content" version="1.0.1">
+    <feature extension="package.version" value="1.0.1"/>
     <feature extension="package.support.name" value="Jason Coleman"/>
     <feature extension="package.support.email" value="jason.coleman@bentley.com"/>
     

--- a/lib/src/main/resources/messages.xml
+++ b/lib/src/main/resources/messages.xml
@@ -10,7 +10,8 @@
     <response/>
   </message>
   <!-- XSLT -->
-  <message id="MJXX001W" type="INFO">
+  <message id="MJXX001I" type="INFO">
     <reason>MathML is converted to referenced SVG but no alt text is available.</reason>
     <response>To include 'alt' text for your resulting image, add an @alttext description to the m:math element in your DITA or MathML source file.</response>
+  </message>
 </messages>  

--- a/lib/src/main/xsl/mathml-d.xsl
+++ b/lib/src/main/xsl/mathml-d.xsl
@@ -124,7 +124,7 @@
                         <xsl:otherwise>
                             <!-- TODO: improve this message with some identifier to the specific m:math element -->
                             <xsl:call-template name="output-message">
-                                <xsl:with-param name="id" select="'MJXX001W'"/>
+                                <xsl:with-param name="id" select="'MJXX001I'"/>
                             </xsl:call-template>
                         </xsl:otherwise>
                     </xsl:choose>


### PR DESCRIPTION
The messages.xml file was invalid (unclosed element). Further, the ID for the alt text info message did not follow [the naming convention for severity scale](https://www.dita-ot.org/dev/topics/error-messages).